### PR TITLE
fix(schema): correct typo in v1.4 

### DIFF
--- a/config/v1.4.json
+++ b/config/v1.4.json
@@ -194,7 +194,7 @@
 								"properties": {
 									"url": {
 										"type": "string",
-										"description": "The URL to the reomte filter."
+										"description": "The URL to the remote filter."
 									},
 									"version": {
 										"type": "string",


### PR DESCRIPTION
filterDefinitions 'url' property from 'reomte' to 'remote'