### PR TITLE
link redirecting to wrong url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The version of the schema matches the version of Regolith. Version v1 will conti
 
 ## Changelog
 ### v1.4
+- Fixed url issue on the bpName and rpName
 - The schema version matches the Regolith version.
 - Changed the "export" configuration. The "target" property of the export can be "development", "world", "local", "exact" or "none"
 - The properties of the "export" change based on the "target".

--- a/config/v1.4.json
+++ b/config/v1.4.json
@@ -55,11 +55,11 @@
 												"enum": ["standard", "education", "preview"]
 											},
 											"rpName": {
-												"description": "The name of the directory for the RP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/).",
+												"description": "The name of the directory for the RP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/ ).",
 												"type": "string"
 											},
 											"bpName": {
-												"description": "The name of the directory for the BP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/).",
+												"description": "The name of the directory for the BP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/ ).",
 												"type": "string"
 											}
 										}
@@ -100,11 +100,11 @@
 												"type": "string"
 											},
 											"rpName": {
-												"description": "The name of the directory for the RP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/).",
+												"description": "The name of the directory for the RP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/ ).",
 												"type": "string"
 											},
 											"bpName": {
-												"description": "The name of the directory for the BP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/).",
+												"description": "The name of the directory for the BP files export defined as an expression evaluated with go-simple-eval (https://github.com/stirante/go-simple-eval/ ).",
 												"type": "string"
 											}
 										}


### PR DESCRIPTION
Currently when pressing ctrl+click on the bpName and rpName url it redirects to the wrong url due to the closing bracket beeing to close to the slash, this just adds a space to it